### PR TITLE
Fix AWS route discovery

### DIFF
--- a/discover-routes.aws.example
+++ b/discover-routes.aws.example
@@ -10,7 +10,7 @@ fi
 export AWS_PROFILE=$(echo ${1} | awk -F"." '{print $2}')
 
 VPC_URL='http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(/sbin/ip link show dev eth0 | grep link/ether | awk '"'"'{print $2}'"'"')/vpc-id'
-VPC_ID=$(ssh ${1} curl -s \"${VPC_URL}\")
+VPC_ID=$(ssh ${SSH_PRIVATE_KEY_OPTS} ${SSH_PORT_OPTS} ${SSH_EXTRA_OPTS} ${1} curl -s \"${VPC_URL}\")
 if [[ ${?} -eq 0 && -n "${VPC_ID}" ]]; then
   FILTER_PARAMS="--filters Name=vpc-id,Values=${VPC_ID}"
 fi

--- a/scripts/client-preexec.sh
+++ b/scripts/client-preexec.sh
@@ -7,4 +7,9 @@ if [[ -f discover-routes ]]; then
     echo "!!! Rewriting stale 'discover-routes' script"
     cp discover-routes.aws.example discover-routes
   fi
+
+  if [[ "$(shasum discover-routes | cut -f1 -d' ')" == "fce86b790248b5c494c360607d27243768f71ec8" ]]; then
+    echo "!!! Rewriting buggy 'discover-routes' script"
+    cp discover-routes.aws.example discover-routes
+  fi
 fi

--- a/xiringuito
+++ b/xiringuito
@@ -113,6 +113,9 @@ if [[ ${#} -gt 0 ]]; then
   declare -r NETWORKS=${@}
 elif [[ -x ./discover-routes && ! ${NO_ROUTE_DISCOVERY} ]]; then
   if [[ ${USE_ROUTE_CACHE} != true ]]; then
+    export SSH_PRIVATE_KEY_OPTS
+    export SSH_PORT_OPTS
+    export SSH_EXTRA_OPTS
     declare -r NETWORKS=$(./discover-routes ${SSH_SERVER} | grep "^ROUTE:" | sed 's/.*://')
     echo "${NETWORKS}" >"${ROUTE_CACHE_FILE}"
   else


### PR DESCRIPTION
If user does not have SSH agent and users non-default SSH-key, AWS route discovery will fail. :scream_cat: 

# GIF
![](https://media.giphy.com/media/6tMe6PtimsGuk/giphy.gif)