### PR TITLE
Ignore expired routes in `netstat` on macOS

### DIFF
--- a/scripts/darwin/get-network-service-name.sh
+++ b/scripts/darwin/get-network-service-name.sh
@@ -7,5 +7,5 @@ if [[ -n "${FORCE_NETWORK_SERVICE}" ]]; then
   exit 0
 fi
 
-DEF_GW_IF=$(netstat -nr | grep default | awk '{print $NF}' | grep -v tun | tail -n1)
+DEF_GW_IF=$(netstat -nr | grep default | awk '!/tun|!/ {print $NF}' | tail -n1)
 networksetup -listnetworkserviceorder | grep -B1 " Device: ${DEF_GW_IF})" | head -n1 | sed 's/^(.*) //'


### PR DESCRIPTION
When routes expire in macOS, `netstat -r` shows a trailing exclamation point to indicate this. In the current version of this code, this will set `DEF_GW_IF` to contain a `!`, causing subsequent DNS modifications on OSX to fail.

This change ignores the the `!` that can be set in this case.